### PR TITLE
Disable last stand, it's broken

### DIFF
--- a/overrides/config/openblocks.cfg
+++ b/overrides/config/openblocks.cfg
@@ -210,7 +210,7 @@ features {
     B:infoBook=true
 
     # Is 'Last Stand' enchantment enabled
-    B:lastStandEnchantment=true
+    B:lastStandEnchantment=false
 
     # Formula for XP cost (variables: hp,dmg,ench,xp). Note: calculation only triggers when hp - dmg < 1.
     S:lastStandFormula=max(1, 50*(1-(hp-dmg))/ench)


### PR DESCRIPTION
Disables the last stand enchantment - untested, breaks existing world. Shouldn't break new ones?