### PR TITLE
v0.3.5 RC2 

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
   "manifestType": "minecraftModpack",
   "manifestVersion": 1,
   "name": "prod (original)",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "author": "asonia",
   "files": [
     {
@@ -325,6 +325,11 @@
       "required": true
     },
     {
+      "projectID": 223008,
+      "fileID": 5274236,
+      "required": true
+    },
+    {
       "projectID": 229045,
       "fileID": 2745548,
       "required": true
@@ -455,6 +460,11 @@
       "required": true
     },
     {
+      "projectID": 311322,
+      "fileID": 2824169,
+      "required": true
+    },
+    {
       "projectID": 223094,
       "fileID": 2482481,
       "required": true
@@ -472,6 +482,11 @@
     {
       "projectID": 237167,
       "fileID": 2985811,
+      "required": true
+    },
+    {
+      "projectID": 373104,
+      "fileID": 3575333,
       "required": true
     },
     {
@@ -547,6 +562,11 @@
     {
       "projectID": 318857,
       "fileID": 2700346,
+      "required": true
+    },
+    {
+      "projectID": 340583,
+      "fileID": 3003242,
       "required": true
     },
     {
@@ -680,6 +700,11 @@
       "required": true
     },
     {
+      "projectID": 236484,
+      "fileID": 3850023,
+      "required": true
+    },
+    {
       "projectID": 272671,
       "fileID": 2843439,
       "required": true
@@ -770,6 +795,11 @@
       "required": true
     },
     {
+      "projectID": 346326,
+      "fileID": 3248796,
+      "required": true
+    },
+    {
       "projectID": 345538,
       "fileID": 2894768,
       "required": true
@@ -847,6 +877,11 @@
     {
       "projectID": 268250,
       "fileID": 3382321,
+      "required": true
+    },
+    {
+      "projectID": 271740,
+      "fileID": 2707353,
       "required": true
     },
     {
@@ -947,6 +982,11 @@
     {
       "projectID": 267602,
       "fileID": 2915363,
+      "required": true
+    },
+    {
+      "projectID": 389665,
+      "fileID": 3247154,
       "required": true
     },
     {

--- a/modlist.html
+++ b/modlist.html
@@ -61,6 +61,7 @@
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/tinkers-tool-leveling">Tinkers' Tool Leveling (by bonusboni)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/tough-as-nails">Tough As Nails (by TheAdubbz)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/thaumic-wonders">Thaumic Wonders (by daedalus4096)</a></li>
+<li><a href="https://www.curseforge.com/minecraft/mc-mods/opencomputers">OpenComputers (by Sangar)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/project-red-integration">Project Red - Integration (by MrTJP)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/item-filters">Item Filters (by LatvianModder)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/additional-structures">Additional Structures (by XxRexRaptorxX)</a></li>
@@ -87,10 +88,12 @@
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/carrots-lib">Carrots Library [FORGE] (by The_Wabbit0101)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/simple-planes">Simple Planes (Forge) (by przemykomo)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/thermal-tinkering">Thermal Tinkering (by samboy063)</a></li>
+<li><a href="https://www.curseforge.com/minecraft/mc-mods/ocdevices">OCDevices (by ben_mkiv)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/inventory-tweaks">Inventory Tweaks [1.12 only]  (by JimeoWan)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/chisel">Chisel (by tterrag1098)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/reauth">ReAuth (by TechnicianLP)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/ftb-library-legacy-forge">FTB Library (Forge) (Legacy) (by FTB)</a></li>
+<li><a href="https://www.curseforge.com/minecraft/mc-mods/elenai-dodge">Elenai Dodge (by ElenaiDev)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/extra-utilities">Extra Utilities (by RWTema)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/thermal-expansion">Thermal Expansion (by TeamCoFH)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/pams-harvestcraft">Pam's HarvestCraft (by pamharvestcraft)</a></li>
@@ -106,6 +109,7 @@
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/chameleon">Chameleon (by Texelsaur)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/reborncore">Reborn Core (by modmuss50)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/huntersreturn">Hunter'sReturn (by bagu_chan500)</a></li>
+<li><a href="https://www.curseforge.com/minecraft/mc-mods/yungs-better-caves">YUNG's Better Caves (Forge) (by YUNGNICKYOUNG)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/cofh-core">CoFH Core (by TeamCoFH)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/the-one-probe">The One Probe (by McJty)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/tesla-core-lib">Tesla Core Lib (by face_of_cat)</a></li>
@@ -132,6 +136,7 @@
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/thaumtweaks">ThaumTweaks (by GrigLog)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/thutcore">ThutCore (by Thutmose_III)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/openmodslib">OpenModsLib (by OpenMods)</a></li>
+<li><a href="https://www.curseforge.com/minecraft/mc-mods/chunk-animator">Chunk Animator (by Lumien231)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/tinkers-complement">Tinkers' Complement (by KnightMiner)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/thaumic-mercy">Thaumic Mercy (by BordListian)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/initial-inventory">Initial Inventory (by Jaredlll08)</a></li>
@@ -150,6 +155,7 @@
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/akashic-tome">Akashic Tome (by Vazkii)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/better-third-person">Better Third Person (by Socolio)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/resource-loader">Resource Loader (by Lumien231)</a></li>
+<li><a href="https://www.curseforge.com/minecraft/mc-mods/commons0815">Commons0815 (by ben_mkiv)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/fermion-core">Fermion Lib (by TheSilkMiner)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/moar-tinkers">Moar Tinkers (by AshuraNoYami)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/crafttweaker">CraftTweaker (by Jaredlll08)</a></li>
@@ -166,6 +172,7 @@
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/shadowfacts-forgelin">Shadowfacts' Forgelin (by ShadowfactsDev)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/thermal-foundation">Thermal Foundation (by TeamCoFH)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/immersive-petroleum">Immersive Petroleum (by Flaxbeard)</a></li>
+<li><a href="https://www.curseforge.com/minecraft/mc-mods/toast-control">Toast Control (by Shadows_of_Fire)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/simpleharvest">SimpleHarvest (by TehNut)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/eleccore">ElecCore (by Elec332)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/tipthescales">TipTheScales (by Jaredlll08)</a></li>
@@ -186,6 +193,7 @@
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/jei-bees">JEI Bees (by bdew)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/quick-leaf-decay">Quick Leaf Decay (by Lumien231)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/ctm">ConnectedTexturesMod (by tterrag1098)</a></li>
+<li><a href="https://www.curseforge.com/minecraft/mc-mods/yungs-better-mineshafts-forge">YUNG's Better Mineshafts (Forge) (by YUNGNICKYOUNG)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/journeymap">JourneyMap (by techbrew)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/reliquary-reincarnations">Reliquary Reincarnations (by P3pp3rF1y)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/thaumic-restoration">Thaumic Restoration (by Zokonius)</a></li>


### PR DESCRIPTION
- Fix parsing error in recipes
- Add new ftbquests
- Fix file reference in merge script
- Add new bounties
- Disable light drifter augment from roots (Spectator game breaking spell), disable broken reliquary items, and opencomputers nanomachines
- Change xnet recipes to not go around ender io conduits
- Update rewards and bounties for bountiful
- Update mods
- Remove newlines
- Add all missing simpleplanes changes

Release candidate 2 for 0.3.5